### PR TITLE
Distribution plots, L1/L2/E-Net loss regularisation, Temperature-scaled sigmoid activation function, Changed export filenames, Other minor improvements

### DIFF
--- a/evaluate_models_utils.py
+++ b/evaluate_models_utils.py
@@ -181,7 +181,7 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                 # # For test_end stage there is no epoch value. If no epochs specified, None is returned.
                 epoch = kwargs.get("epoch", None)
                 if epoch != None:
-                    save_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_epoch-{epoch}_all-edges_distributions")
+                    save_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_epoch-{epoch:04d}_all-edges_distributions")
                 else:
                     save_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_distributions")
                 
@@ -231,7 +231,7 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                     dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
 
                     # Get the file name (individual edges in "test_end")
-                    save_edge_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_src-{src_node_id}_dst-{dst_node_id}_edge-{edge_ids_array[i]}_{src_date_str}-{dst_date_str}_distributions")
+                    save_edge_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_distributions")
 
                     # Plot the distributions (individual edges in "test_end")
                     evaluate_image_link_prediction_plot_distributions(logger=logger,
@@ -265,7 +265,7 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                 dst_date = node_mapping.loc[node_mapping['nodeID'] == dst_node_id, 'date'].values[0]
                 src_date_str = pd.to_datetime(src_date).strftime('%Y%m%d')
                 dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
-                save_name = os.path.join(result_folder, f"{eval_stage}_src-{src_node_id}_dst-{dst_node_id}_edge-{edge_ids_array[i]}_{src_date_str}-{dst_date_str}") 
+                save_name = os.path.join(result_folder, f"{eval_stage}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}") 
                 
                 # Reshape ground truth and prediction into 2D
                 gt_2d = reshape_to_2d(gt_embeddings[i], H, W)

--- a/utils/load_configs.py
+++ b/utils/load_configs.py
@@ -46,6 +46,8 @@ def get_link_prediction_args(is_evaluation: bool = False):
     parser.add_argument('--num_epochs', type=int, default=100, help='number of epochs')
     parser.add_argument('--optimizer', type=str, default='Adam', choices=['SGD', 'Adam', 'RMSprop'], help='name of optimizer')
     parser.add_argument('--weight_decay', type=float, default=0.0, help='weight decay')
+    parser.add_argument('--l1_regularisation_lambda', type=float, default=0.0, help='L1 regularisation (Lasso) lambda hyperparameter')
+    parser.add_argument('--l2_regularisation_lambda', type=float, default=0.0, help='L2 regularisation (Ridge) lambda hyperparameter')
     parser.add_argument('--patience', type=int, default=10, help='patience for early stopping in terms of no. of epochs')
     parser.add_argument('--patience_threshold', type=int, default=0.005, help='patience for early stopping in terms of loss threshold, stop early if loss does not improve significantly enough e.g. by 0.005')
     parser.add_argument('--num_runs', type=int, default=5, help='number of runs')


### PR DESCRIPTION
Key Updates:

1) Implemented distribution plots with integrated percentile displays for val (per epoch collectively for all edges) & test_end (collectively for all edges and each individual edge)
2) Implemented optional L1/L2/E-Net loss regularisation; controlled by lambda values in utils/load_configs.py; regularisation is not active by default
3) Implemented temperature-scaling option for sigmoid activation function in models/modules.py.
4) Changed all epoch, nodes, and edge numbers in exported files to be 4 digits for better organisation (e.g. "test_end_src-0025_dst-0030_edge-0231_20241029-20241228_distributions.png")
5) Logging improvements 
6) Reorganisation of some script components
