### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This repository follows the [DyGLib_TGB](https://github.com/yule-BUAA/DyGLib_TGB) repository. 
 We extend DyGLib_TGB to the remote sensing data.
 
+
 ## Dynamic Graph Learning Models
 Eleven dynamic graph learning methods are included in DyGLib_TGB, including 
 [JODIE](https://dl.acm.org/doi/10.1145/3292500.3330895), 
@@ -23,6 +24,7 @@ Eleven dynamic graph learning methods are included in DyGLib_TGB, including
 ## Evaluation Tasks
 Given the known coherence image, we regard these images as the edge features and the amplitude image as the node feature. The task is to predict the unknown edge feature.
 
+
 ## Environments
 [PyTorch 2.0.1](https://pytorch.org/), 
 [py-tgb](https://pypi.org/project/py-tgb/),
@@ -30,8 +32,142 @@ Given the known coherence image, we regard these images as the edge features and
 [tqdm](https://pypi.org/project/tqdm/).
 You can use pip or conda tools to install these packages.
 
+## Installation
+Do the following in a clean conda environment (note that seaborn has been added as of 12 July 2025, have only tested its installation independently after pip install):  
+$ source /home/tayw0049/miniconda3/etc/profile.d/conda.sh 
+$ conda create -n image_prediction python=3.9 
+$ conda activate image_prediction 
+$ pip install py-tgb numpy==1.23.5 pandas==1.5.3 torch torchvision torchaudio matplotlib scikit-image 
+$ conda install seaborn 
+
+Check installed packages: 
+$ conda list 
+packages in environment at /home/tayw0049/miniconda3/envs/image_prediction:                                                                                                                                           
+Name                      Version                   Build  Channel          
+_libgcc_mutex             0.1                        main
+_openmp_mutex             5.1                       1_gnu
+aiohappyeyeballs          2.6.1                    pypi_0    pypi
+aiohttp                   3.11.13                  pypi_0    pypi
+aiosignal                 1.3.2                    pypi_0    pypi 
+args                      0.1.0                    pypi_0    pypi
+async-timeout             5.0.1                    pypi_0    pypi
+attrs                     25.1.0                   pypi_0    pypi
+blas                      1.0                         mkl
+bottleneck                1.4.2            py39ha9d4c09_0
+brotli-python             1.0.9            py39h6a678d5_9
+ca-certificates           2025.2.25            h06a4308_0
+certifi                   2025.1.31                pypi_0    pypi
+charset-normalizer        3.4.1                    pypi_0    pypi
+clint                     0.5.1                    pypi_0    pypi
+contourpy                 1.3.0                    pypi_0    pypi
+cycler                    0.12.1                   pypi_0    pypi
+filelock                  3.17.0                   pypi_0    pypi
+fonttools                 4.56.0                   pypi_0    pypi
+freetype                  2.13.3               h4a9f257_0  
+frozenlist                1.5.0                    pypi_0    pypi
+fsspec                    2025.3.0                 pypi_0    pypi
+idna                      3.10                     pypi_0    pypi
+imageio                   2.37.0                   pypi_0    pypi
+importlib-resources       6.5.2                    pypi_0    pypi
+importlib_resources       6.4.0            py39h06a4308_0  
+intel-openmp              2023.1.0         hdb19cb5_46306  
+jinja2                    3.1.6                    pypi_0    pypi
+joblib                    1.4.2                    pypi_0    pypi
+jpeg                      9e                   h5eee18b_3  
+kiwisolver                1.4.7                    pypi_0    pypi
+lazy-loader               0.4                      pypi_0    pypi
+lcms2                     2.16                 h92b89f2_1  
+ld_impl_linux-64          2.40                 h12ee557_0  
+lerc                      4.0.0                h6a678d5_0  
+libdeflate                1.22                 h5eee18b_0  
+libffi                    3.4.4                h6a678d5_1  
+libgcc-ng                 11.2.0               h1234567_1  
+libgomp                   11.2.0               h1234567_1  
+libpng                    1.6.39               h5eee18b_0  
+libstdcxx-ng              11.2.0               h1234567_1  
+libtiff                   4.7.0                hde9077f_0  
+libwebp-base              1.3.2                h5eee18b_1  
+lz4-c                     1.9.4                h6a678d5_1  
+markupsafe                3.0.2                    pypi_0    pypi
+matplotlib                3.9.4                    pypi_0    pypi
+matplotlib-base           3.9.2            py39hbfdbfaf_1  
+mkl                       2023.1.0         h213fc3f_46344  
+mkl-service               2.4.0            py39h5eee18b_2  
+mkl_fft                   1.3.11           py39h5eee18b_0  
+mkl_random                1.2.8            py39h1128e8f_0  
+mpmath                    1.3.0                    pypi_0    pypi
+multidict                 6.1.0                    pypi_0    pypi
+ncurses                   6.4                  h6a678d5_0  
+networkx                  3.2.1                    pypi_0    pypi
+numexpr                   2.10.1           py39h3c60e43_0  
+numpy                     1.23.5                   pypi_0    pypi
+numpy-base                2.0.1            py39hb5e798b_1  
+nvidia-cublas-cu12        12.4.5.8                 pypi_0    pypi
+nvidia-cuda-cupti-cu12    12.4.127                 pypi_0    pypi
+nvidia-cuda-nvrtc-cu12    12.4.127                 pypi_0    pypi
+nvidia-cuda-runtime-cu12  12.4.127                 pypi_0    pypi
+nvidia-cudnn-cu12         9.1.0.70                 pypi_0    pypi
+nvidia-cufft-cu12         11.2.1.3                 pypi_0    pypi
+nvidia-curand-cu12        10.3.5.147               pypi_0    pypi
+nvidia-cusolver-cu12      11.6.1.9                 pypi_0    pypi
+nvidia-cusparse-cu12      12.3.1.170               pypi_0    pypi
+nvidia-cusparselt-cu12    0.6.2                    pypi_0    pypi
+nvidia-nccl-cu12          2.21.5                   pypi_0    pypi
+nvidia-nvjitlink-cu12     12.4.127                 pypi_0    pypi
+nvidia-nvtx-cu12          12.4.127                 pypi_0    pypi
+openjpeg                  2.5.2                h0d4d230_1  
+openssl                   3.0.16               h5eee18b_0  
+packaging                 24.2             py39h06a4308_0  
+pandas                    1.5.3                    pypi_0    pypi
+pillow                    11.1.0           py39hac6e08b_1  
+pip                       25.0             py39h06a4308_0  
+propcache                 0.3.0                    pypi_0    pypi
+psutil                    7.0.0                    pypi_0    pypi
+py-tgb                    2.0.0                    pypi_0    pypi
+pyparsing                 3.2.1                    pypi_0    pypi
+python                    3.9.21               he870216_1  
+python-dateutil           2.9.0post0       py39h06a4308_2  
+python-tzdata             2025.2             pyhd3eb1b0_0  
+pytz                      2025.1                   pypi_0    pypi
+readline                  8.2                  h5eee18b_0  
+requests                  2.32.3                   pypi_0    pypi
+scikit-image              0.24.0                   pypi_0    pypi
+scikit-learn              1.6.1                    pypi_0    pypi
+scipy                     1.13.1                   pypi_0    pypi
+seaborn                   0.13.2           py39h06a4308_3  
+setuptools                75.8.0           py39h06a4308_0  
+six                       1.17.0           py39h06a4308_0  
+sqlite                    3.45.3               h5eee18b_0  
+sympy                     1.13.1                   pypi_0    pypi
+tbb                       2021.8.0             hdb19cb5_0  
+threadpoolctl             3.5.0                    pypi_0    pypi
+tifffile                  2024.8.30                pypi_0    pypi
+tk                        8.6.14               h39e8969_0  
+torch                     2.6.0                    pypi_0    pypi
+torch-geometric           2.6.1                    pypi_0    pypi
+torchaudio                2.6.0                    pypi_0    pypi
+torchvision               0.21.0                   pypi_0    pypi
+tqdm                      4.67.1                   pypi_0    pypi
+triton                    3.2.0                    pypi_0    pypi
+typing-extensions         4.12.2                   pypi_0    pypi
+tzdata                    2025a                h04d1e81_0  
+unicodedata2              15.1.0           py39h5eee18b_1  
+urllib3                   2.3.0                    pypi_0    pypi
+wheel                     0.45.1           py39h06a4308_0  
+xz                        5.6.4                h5eee18b_1  
+yarl                      1.18.3                   pypi_0    pypi
+zipp                      3.21.0           py39h06a4308_0  
+zlib                      1.2.13               h5eee18b_1  
+zstd                      1.5.6                hc292b87_0
+
+As part of the tgb installation, other packages such as pytorch, tqdm, scikit-learn will be installed along with tgb too. However, other packages such as torch, matplotlib, and scikit-image will not be installed and need to be specified during installation. 
+
+Note that tgb can only be installed using pip and requires pandas <2.00 >=1.5.3. Note that pandas 1.5.3 is only compatible with earlier versions of numpy, e.g. numpy 1.23.5. By default, tgb would install a later numpy version 2.0.2, so the numpy and pandas versions need to be specified when installing tgb. See more about tgb here: https://github.com/shenyangHuang/TGB. If there is a numpy and pandas conflict, there would be errors when running a python code which imports scikit-learn, pandas or tgb
+
 
 ## Executing Scripts
 You can change the "--model_name" parameter into other models
+
+
 ### Scripts for Dynamic Link Property Prediction
 python image_link_prediction.py --dataset_name tgbl-wiki --model_name TCL --patch_size 1 --max_input_sequence_length 32 --num_runs 5 --gpu 0

--- a/cor_logit_space.py
+++ b/cor_logit_space.py
@@ -1,0 +1,121 @@
+# Inspired by "Deep Learning-Based Damage Mapping With InSAR Coherence Time Series" by Stephenson et al. (2021).
+# Converts coherences in [0,1] to logit space in (-inf, +inf). 
+# By default, logit transformation is applied to the square of the coherence values as they are mathematically closely equivalent to the "logarithm of the variance of the interferometric phase".
+# Example Usage:
+# python cor_logit_space.py -i /aria/zulun_sharing/TEST_KZ_TGNN_sharing_20250214/merged/cors_ALL -s 1 -eps 1e-4 &> cor_logit_space_$(date +%Y%m%d_%H%M%S).log
+# python cor_logit_space.py -i /aria/tgnn_dpm5/usa_california_wildfires/P064/merged/cors -s 1 -eps 1e-4 &> cor_logit_space_$(date +%Y%m%d_%H%M%S).log
+
+
+import os
+import sys
+import argparse
+import glob
+import re
+import numpy as np 
+from utils.isce_tools import sizeFromXml, readCor
+
+
+# Set up argparse
+def cmdLineParse():
+    parser = argparse.ArgumentParser(description='Converts the coherences in the domain of [0,1] to logit space (-inf, +inf)')
+    parser.add_argument('-i', dest='in_dir', type=str, required=True, 
+            help = 'Path to merged/cor directory containing the coherence files')
+    parser.add_argument('-s', dest='save', type=int, default=0,
+            help = 'Flag to save logit-transformed squared coherences (1: save, 0: do not save)'),
+    parser.add_argument('-eps', dest='eps', type=float, default=1e-4,
+            help = 'Small epsilon to clip squared coherence values and avoid division by zero or log(0) (default: 1e-4)')
+    
+    args = parser.parse_args()
+
+    if len(sys.argv) <= 1:
+        print('')
+        parser.print_help()
+        sys.exit(1)
+    else:
+        return args
+
+
+# Coherence to logit space transformation
+def cor_to_logit(cor, eps=1e-4):
+
+    # Clip squared coherence values into (0, 1) to avoid 0 and 1
+    cor_squared = np.clip(np.square(cor), eps, 1 - eps)
+
+    # Report how many values were clipped
+    num_clipped = np.sum((cor_squared <= eps) | (cor_squared >= 1 - eps))
+    if num_clipped > 0:
+        print(f"[WARNING] {num_clipped} coherence values were clipped to avoid numerical issues.")
+
+    # Apply logit transformation on squared coherences
+    logit_cor = np.log(cor_squared / (1 - cor_squared))
+
+    return logit_cor
+
+
+# Logit space to coherence transformation
+def logit_to_cor(logit_cor):
+    cor = np.sqrt(1 / (1 + np.exp(-logit_cor)))
+    return cor
+
+
+def saveCor(width, length, cor, cor_ori):
+    # Write to new coherence file
+    cor_new = cor_ori[:-4] + f'_logit.cor'
+    cor_data = np.zeros((length * 2, width), dtype=np.float32)
+    cor_data[1:length * 2:2, :] = cor
+    cor_data.astype(np.float32).tofile(cor_new)
+
+    # Create VRT and XML files
+    vrt_ori = cor_ori + '.vrt'
+    vrt_new = cor_new + '.vrt'
+    with open(vrt_ori, 'r') as f:
+        content = f.read()
+    content = content.replace('lks.cor', 'lks_logit.cor')
+    with open(vrt_new, 'w') as f:
+        f.write(content)
+    xml_ori = cor_ori + '.xml'
+    xml_new = cor_new + '.xml'
+    with open(xml_ori, 'r') as f:
+        content = f.read()
+    content = content.replace('lks.cor', 'lks_logit.cor')
+    with open(xml_new, 'w') as f:
+        f.write(content)
+
+
+# Main script to convert coherences to logit space
+if __name__ == '__main__':
+
+    # Parse command line arguments
+    inps = cmdLineParse()
+
+    # Get list of coherence files
+    glob_str = inps.in_dir + '/cor_????????_????????/b01_16r4alks.cor'
+    cor_files = sorted(glob.glob(glob_str))
+
+    # Read the first coherence file to get dimensions (width and length)
+    width, length = sizeFromXml(cor_files[0])
+    
+    # Convert coherences to logit space
+    for cor_file in cor_files:
+        print(f'Reading coherence file: {cor_file}')
+        
+        # Read the coherence data
+        cor = readCor(cor_file, [0, length, 0, width])
+    
+        # Convert coherence to logit space
+        logit_cor = cor_to_logit(cor)
+
+        # Print statistics of the coherence
+        print(f"\n"
+              f"Statistics for original coherence [ MIN | 1st | 25th | 50th | 75th | 99th | MAX ]\n"
+              f"{np.min(cor):.4f} | {np.percentile(cor, 1):.4f} | {np.percentile(cor, 25):.4f} | {np.median(cor):.4f} | {np.percentile(cor, 75):.4f} | {np.percentile(cor, 99):.4f} | {np.max(cor):.4f}\n"
+              f"\n"
+              f"Statistics for logit space transformed coherence [ MIN | 1st | 25th | 50th | 75th | 99th | MAX ]\n"
+              f"{np.min(logit_cor):.4f} | {np.percentile(logit_cor, 1):.4f} | {np.percentile(logit_cor, 25):.4f} | {np.median(logit_cor):.4f} | {np.percentile(logit_cor, 75):.4f} | {np.percentile(logit_cor, 99):.4f} | {np.max(logit_cor):.4f}\n"
+              f"\n")
+        
+        # Save the logit-transformed coherences if specified
+        if inps.save == 1:
+            logit_cor_file = cor_file[:-4] + '_logit.cor'
+            saveCor(width, length, logit_cor, cor_file)
+            print(f"Saved logit-transformed coherence to: {logit_cor_file}\n\n")

--- a/evaluate_models_utils.py
+++ b/evaluate_models_utils.py
@@ -129,12 +129,12 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
         else:
             raise ValueError(f"Wrong value for model_name {model_name}!")
 
-        # # Predict the positive probabilities
-        # # UNCOMMENT FOR DEBUGGING: Uncomment the following lines for edge predictions with different modification operations
-        # # When changing the following lines, we must also change the edge prediction lines in "image_link_prediction.py"
-        # # (1) predictions without modification operations 
-        # # (2) predictions with an external sigmoid operation (not recommended)
-        # # (3) predictions with an external clamp operation (not recommended)
+        # Predict the positive probabilities
+        # UNCOMMENT FOR DEBUGGING: Uncomment the following lines for edge predictions with different modification operations
+        # When changing the following lines, we must also change the edge prediction lines in "image_link_prediction.py"
+        # (1) predictions without modification operations 
+        # (2) predictions with an external sigmoid operation (not recommended)
+        # (3) predictions with an external clamp operation (not recommended)
         positive_probabilities = model[1](input_1=src_node_embeddings, input_2=dst_node_embeddings).squeeze(dim=-1).cpu().numpy()
         # positive_probabilities = model[1](input_1=src_node_embeddings, input_2=dst_node_embeddings).squeeze(dim=-1).sigmoid().cpu().numpy()
         # positive_probabilities = model[1](input_1=src_node_embeddings, input_2=dst_node_embeddings).squeeze(dim=-1).clamp(min=0.0, max=1.0).cpu().numpy()
@@ -177,8 +177,8 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
             # Plot distributions for evaluation stages (except for "test_end")
             if eval_stage != "test_end":
 
-                # # Get the relevant epoch that is being evaluated (mainly for validation stage). 
-                # # For test_end stage there is no epoch value. If no epochs specified, None is returned.
+                # Get the relevant epoch that is being evaluated (mainly for validation stage) 
+                # For test_end stage there is no epoch value. If no epochs specified, None is returned
                 epoch = kwargs.get("epoch", None)
                 if epoch != None:
                     save_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_epoch-{epoch:04d}_all-edges_distributions")

--- a/evaluate_models_utils.py
+++ b/evaluate_models_utils.py
@@ -186,7 +186,7 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                 dst_date = node_mapping.loc[node_mapping['nodeID'] == dst_node_id, 'date'].values[0]
                 src_date_str = pd.to_datetime(src_date).strftime('%Y%m%d')
                 dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
-                save_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_visual")                  
+                save_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}")                  
                 
                 # Reshape ground truth and prediction into 2D
                 gt_2d = reshape_to_2d(gt_embeddings[i], H, W)
@@ -200,7 +200,7 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                 np.save(save_name + "_residualabs.npy", np.abs(residual_2d))
                 
                 # Visualize results
-                evaluate_image_link_prediction_visualiser(logger, gt_2d, pred_2d, save_name + ".png")  
+                evaluate_image_link_prediction_visualiser(logger, gt_2d, pred_2d, save_name + "_visual.png")  
 
         # Plot distributions of all edges collectively in the epoch for GT, Pred, Residuals, abs(Residuals)
         if distributions_all:
@@ -216,13 +216,13 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
             abs_residuals_dist_flat = np.abs(residuals_full_object).flatten()
 
             # Plot results
-            save_distributions_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_all-edges_distributions")
+            save_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_all-edges_distributions")
             evaluate_image_link_prediction_plot_distributions(logger=logger,
                                                                 gt_img=gt_dist_flat,
                                                                 pred_img=pred_dist_flat,
                                                                 residuals_img=residuals_dist_flat,
                                                                 abs_residuals_img=abs_residuals_dist_flat,
-                                                                save_path=save_distributions_name+".png")
+                                                                save_path=save_name+".png")
         
         # Plot distributions of each individual edge in the epoch for GT, Pred, Residuals, abs(Residuals)
         if distributions:
@@ -252,13 +252,13 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                 dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
 
                 # Plot results
-                save_edge_distributions_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_distributions")
+                save_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_distributions")
                 evaluate_image_link_prediction_plot_distributions(logger=logger,
                                                                     gt_img=gt_edge_dist_flat,
                                                                     pred_img=pred_edge_dist_flat,
                                                                     residuals_img=residuals_edge_dist_flat,
                                                                     abs_residuals_img=abs_residuals_edge_dist_flat,
-                                                                    save_path=save_edge_distributions_name+".png")            
+                                                                    save_path=save_name+".png")            
 
         # Compute loss (using MAE / L1 loss here)
         loss = np.mean(np.abs(edge_raw_features[edge_ids_array] - positive_probabilities))

--- a/evaluate_models_utils.py
+++ b/evaluate_models_utils.py
@@ -45,8 +45,9 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                                                     l1_regularisation_lambda: float = 0.0,
                                                     l2_regularisation_lambda: float = 0.0,
                                                     visualize: bool = False,
-                                                    plot_distributions: bool = True,
-                                                    **kwargs):
+                                                    distributions_all: bool = True,
+                                                    distributions: bool = True,
+                                                    epoch: int = 1):
     """
     Evaluate models on the link prediction task without requiring a data loader
     Processing all edges in a single batch
@@ -161,125 +162,8 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                     f"abs(GROUND TRUTH - PREDICTION) Percentiles: \n"
                     f"{np.percentile(np.abs(residuals_full_object), [0, 1, 25, 50, 75, 99, 100])}\n")
 
-        # Plotting distributions for GT, Pred, Residuals, abs(Residuals)
-        if eval_stage == "test_end" or plot_distributions:
-
-            # Create the output folder if it doesn't exist
-            image_distributions_folder = os.path.join(os.getcwd(), "image_distributions")
-            os.makedirs(image_distributions_folder, exist_ok=True)
-
-            # Flatten the GT, Pred, Residuals, abs(Residuals) objects for distribution plotting
-            gt_dist_flat = edge_raw_features[edge_ids_array].flatten()
-            pred_dist_flat = positive_probabilities.flatten()
-            residuals_dist_flat = residuals_full_object.flatten()
-            abs_residuals_dist_flat = np.abs(residuals_full_object).flatten()
-
-            # Plot distributions for evaluation stages (except for "test_end")
-            if eval_stage != "test_end":
-
-                # Get the relevant epoch that is being evaluated (mainly for validation stage) 
-                # For test_end stage there is no epoch value. If no epochs specified, None is returned
-                epoch = kwargs.get("epoch", None)
-                if epoch != None:
-                    save_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_epoch-{epoch:04d}_all-edges_distributions")
-                else:
-                    save_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_distributions")
-                
-                # Plot the distributions for the "train / val" stages
-                # First, plot distributions of all edges collectively in the "train / val" stages
-                evaluate_image_link_prediction_plot_distributions(logger=logger,
-                                                                  gt_img=gt_dist_flat,
-                                                                  pred_img=pred_dist_flat,
-                                                                  residuals_img=residuals_dist_flat,
-                                                                  abs_residuals_img=abs_residuals_dist_flat,
-                                                                  save_path=save_distributions_name+".png")
-                
-                # Next, plot distributions of each individual edge in the "train / val" stages
-                # Get the num_edges and relevant node and date information for each edge
-                num_edges = positive_probabilities.shape[0]
-
-                # Iterate through the individual edges
-                for i in range(num_edges):
-
-                    # Flatten the GT, Pred, Residuals, abs(Residuals) objects for each edge for distribution plotting
-                    gt_edge_dist_flat = edge_raw_features[edge_ids_array][i].flatten()
-                    pred_edge_dist_flat = positive_probabilities[i].flatten()
-                    residuals_edge_dist_flat = residuals_full_object[i].flatten()
-                    abs_residuals_edge_dist_flat = np.abs(residuals_full_object)[i].flatten()
-
-                    # Get dates from node and edge mappings
-                    edge_id = edge_ids_array[i]
-                    src_node_id, dst_node_id = edge_node_pairs[edge_id-1]
-                    src_date = node_mapping.loc[node_mapping['nodeID'] == src_node_id, 'date'].values[0]
-                    dst_date = node_mapping.loc[node_mapping['nodeID'] == dst_node_id, 'date'].values[0]
-                    src_date_str = pd.to_datetime(src_date).strftime('%Y%m%d')
-                    dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
-
-                    # Get the relevant epoch that is being evaluated (mainly for validation stage).
-                    epoch = kwargs.get("epoch", None)
-                    if epoch != None:
-                        save_edge_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_distributions")
-                    else:
-                        save_edge_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_distributions")
-                    
-                    # Plot the distributions (individual edges in "train / val")
-                    evaluate_image_link_prediction_plot_distributions(logger=logger,
-                                                                      gt_img=gt_edge_dist_flat,
-                                                                      pred_img=pred_edge_dist_flat,
-                                                                      residuals_img=residuals_edge_dist_flat,
-                                                                      abs_residuals_img=abs_residuals_edge_dist_flat,
-                                                                      save_path=save_edge_distributions_name+".png")
-
-            # Plot distributions for the "test_end" evaluation stage
-            # For the "test_end" stage, we plot the distributions of (1) all edges collectively, and (2) each individual edge
-            elif eval_stage == "test_end":
-
-                # First, plot distributions of all edges collectively in "test_end"
-                # Get the file name (all edges collectively in "test_end")
-                save_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_all-edges_distributions")
-
-                # Plot the distributions (all edges collectively in "test_end")
-                evaluate_image_link_prediction_plot_distributions(logger=logger,
-                                                                  gt_img=gt_dist_flat,
-                                                                  pred_img=pred_dist_flat,
-                                                                  residuals_img=residuals_dist_flat,
-                                                                  abs_residuals_img=abs_residuals_dist_flat,
-                                                                  save_path=save_distributions_name+".png")
-                
-                # Next, plot distributions of each individual edge in "test_end"
-                # Get the num_edges and relevant node and date information for each edge
-                num_edges = positive_probabilities.shape[0]
-
-                # Iterate through the individual edges
-                for i in range(num_edges):
-
-                    # Flatten the GT, Pred, Residuals, abs(Residuals) objects for each edge for distribution plotting
-                    gt_edge_dist_flat = edge_raw_features[edge_ids_array][i].flatten()
-                    pred_edge_dist_flat = positive_probabilities[i].flatten()
-                    residuals_edge_dist_flat = residuals_full_object[i].flatten()
-                    abs_residuals_edge_dist_flat = np.abs(residuals_full_object)[i].flatten()
-
-                    # Get dates from node and edge mappings
-                    edge_id = edge_ids_array[i]
-                    src_node_id, dst_node_id = edge_node_pairs[edge_id-1]
-                    src_date = node_mapping.loc[node_mapping['nodeID'] == src_node_id, 'date'].values[0]
-                    dst_date = node_mapping.loc[node_mapping['nodeID'] == dst_node_id, 'date'].values[0]
-                    src_date_str = pd.to_datetime(src_date).strftime('%Y%m%d')
-                    dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
-
-                    # Get the file name (individual edges in "test_end")
-                    save_edge_distributions_name = os.path.join(image_distributions_folder, f"{eval_stage}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_distributions")
-
-                    # Plot the distributions (individual edges in "test_end")
-                    evaluate_image_link_prediction_plot_distributions(logger=logger,
-                                                                      gt_img=gt_edge_dist_flat,
-                                                                      pred_img=pred_edge_dist_flat,
-                                                                      residuals_img=residuals_edge_dist_flat,
-                                                                      abs_residuals_img=abs_residuals_edge_dist_flat,
-                                                                      save_path=save_edge_distributions_name+".png")
-
-        # For test_end stage or if visualise is set to true, visualize results 
-        if eval_stage == "test_end" or visualize:
+        # Visualizing GT, Pred, Residuals, abs(Residuals)
+        if visualize:
             # Create the output folder if it doesn't exist
             result_folder = os.path.join(os.getcwd(), "image_result")
             os.makedirs(result_folder, exist_ok=True)
@@ -302,14 +186,7 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                 dst_date = node_mapping.loc[node_mapping['nodeID'] == dst_node_id, 'date'].values[0]
                 src_date_str = pd.to_datetime(src_date).strftime('%Y%m%d')
                 dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
-
-                # # Get the relevant epoch that is being evaluated (mainly for validation stage). 
-                # # For test_end stage there is no epoch value. If no epochs specified, None is returned.
-                epoch = kwargs.get("epoch", None)
-                if epoch != None:
-                    save_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}") 
-                else:                    
-                    save_name = os.path.join(result_folder, f"{eval_stage}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}") 
+                save_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_visual")                  
                 
                 # Reshape ground truth and prediction into 2D
                 gt_2d = reshape_to_2d(gt_embeddings[i], H, W)
@@ -323,7 +200,65 @@ def evaluate_image_link_prediction_without_dataloader(logger: str,
                 np.save(save_name + "_residualabs.npy", np.abs(residual_2d))
                 
                 # Visualize results
-                evaluate_image_link_prediction_visualiser(logger, gt_2d, pred_2d, save_name + ".png")              
+                evaluate_image_link_prediction_visualiser(logger, gt_2d, pred_2d, save_name + ".png")  
+
+        # Plot distributions of all edges collectively in the epoch for GT, Pred, Residuals, abs(Residuals)
+        if distributions_all:
+
+            # Create the output folder if it doesn't exist
+            result_folder = os.path.join(os.getcwd(), "image_result")
+            os.makedirs(result_folder, exist_ok=True)
+
+            # Flatten the GT, Pred, Residuals, abs(Residuals) objects for distribution plotting
+            gt_dist_flat = edge_raw_features[edge_ids_array].flatten()
+            pred_dist_flat = positive_probabilities.flatten()
+            residuals_dist_flat = residuals_full_object.flatten()
+            abs_residuals_dist_flat = np.abs(residuals_full_object).flatten()
+
+            # Plot results
+            save_distributions_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_all-edges_distributions")
+            evaluate_image_link_prediction_plot_distributions(logger=logger,
+                                                                gt_img=gt_dist_flat,
+                                                                pred_img=pred_dist_flat,
+                                                                residuals_img=residuals_dist_flat,
+                                                                abs_residuals_img=abs_residuals_dist_flat,
+                                                                save_path=save_distributions_name+".png")
+        
+        # Plot distributions of each individual edge in the epoch for GT, Pred, Residuals, abs(Residuals)
+        if distributions:
+            
+            # Create the output folder if it doesn't exist
+            result_folder = os.path.join(os.getcwd(), "image_result")
+            os.makedirs(result_folder, exist_ok=True)
+            
+            # Get the num_edges and relevant node and date information for each edge
+            num_edges = positive_probabilities.shape[0]
+
+            # Iterate through the individual edges
+            for i in range(num_edges):
+
+                # Flatten the GT, Pred, Residuals, abs(Residuals) objects for each edge for distribution plotting
+                gt_edge_dist_flat = edge_raw_features[edge_ids_array][i].flatten()
+                pred_edge_dist_flat = positive_probabilities[i].flatten()
+                residuals_edge_dist_flat = residuals_full_object[i].flatten()
+                abs_residuals_edge_dist_flat = np.abs(residuals_full_object)[i].flatten()
+
+                # Get dates from node and edge mappings
+                edge_id = edge_ids_array[i]
+                src_node_id, dst_node_id = edge_node_pairs[edge_id-1]
+                src_date = node_mapping.loc[node_mapping['nodeID'] == src_node_id, 'date'].values[0]
+                dst_date = node_mapping.loc[node_mapping['nodeID'] == dst_node_id, 'date'].values[0]
+                src_date_str = pd.to_datetime(src_date).strftime('%Y%m%d')
+                dst_date_str = pd.to_datetime(dst_date).strftime('%Y%m%d')
+
+                # Plot results
+                save_edge_distributions_name = os.path.join(result_folder, f"{eval_stage}_epoch-{epoch:04d}_src-{src_node_id:04d}_dst-{dst_node_id:04d}_edge-{edge_ids_array[i]:04d}_{src_date_str}-{dst_date_str}_distributions")
+                evaluate_image_link_prediction_plot_distributions(logger=logger,
+                                                                    gt_img=gt_edge_dist_flat,
+                                                                    pred_img=pred_edge_dist_flat,
+                                                                    residuals_img=residuals_edge_dist_flat,
+                                                                    abs_residuals_img=abs_residuals_edge_dist_flat,
+                                                                    save_path=save_edge_distributions_name+".png")            
 
         # Compute loss (using MAE / L1 loss here)
         loss = np.mean(np.abs(edge_raw_features[edge_ids_array] - positive_probabilities))

--- a/models/TCL.py
+++ b/models/TCL.py
@@ -65,71 +65,140 @@ class TCL(nn.Module):
         :param num_neighbors: int, number of neighbors to sample for each node
         :return:
         """
-        # get temporal neighbors of source nodes, including neighbor ids, edge ids and time information
-        # src_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors)
-        # src_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors)
-        # src_neighbor_times, ndarray, shape (batch_size, num_neighbors)
-        src_neighbor_node_ids, src_neighbor_edge_ids, src_neighbor_times = \
-            self.neighbor_sampler.get_historical_neighbors(node_ids=src_node_ids,
-                                                           node_interact_times=node_interact_times,
-                                                           num_neighbors=num_neighbors)
+        
+        # GET FEATURES: ALL RECENT NEIGHBORS WITHIN THE BATCH, ORIGINAL TCL APPROACH
+        # # get temporal neighbors of source nodes, including neighbor ids, edge ids and time information
+        # # src_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors)
+        # # src_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors)
+        # # src_neighbor_times, ndarray, shape (batch_size, num_neighbors)
+        # src_neighbor_node_ids, src_neighbor_edge_ids, src_neighbor_times = \
+        #     self.neighbor_sampler.get_historical_neighbors(node_ids=src_node_ids,
+        #                                                    node_interact_times=node_interact_times,
+        #                                                    num_neighbors=num_neighbors)
 
-        # get temporal neighbors of destination nodes, including neighbor ids, edge ids and time information
-        # dst_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors)
-        # dst_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors)
-        # dst_neighbor_times, ndarray, shape (batch_size, num_neighbors)
-        dst_neighbor_node_ids, dst_neighbor_edge_ids, dst_neighbor_times = \
-            self.neighbor_sampler.get_historical_neighbors(node_ids=dst_node_ids,
-                                                           node_interact_times=node_interact_times,
-                                                           num_neighbors=num_neighbors)
+        # # get temporal neighbors of destination nodes, including neighbor ids, edge ids and time information
+        # # dst_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors)
+        # # dst_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors)
+        # # dst_neighbor_times, ndarray, shape (batch_size, num_neighbors)
+        # dst_neighbor_node_ids, dst_neighbor_edge_ids, dst_neighbor_times = \
+        #     self.neighbor_sampler.get_historical_neighbors(node_ids=dst_node_ids,
+        #                                                    node_interact_times=node_interact_times,
+        #                                                    num_neighbors=num_neighbors)
+        
+        # def fill_initial_zeros(arr):
+        #     result = arr.copy()
+        #     for i in range(result.shape[0]):
+        #         first = result[i, 0]
+        #         for j in range(1, result.shape[1]):
+        #             if result[i, j] == 0:
+        #                 result[i, j] = first
+        #             else:
+        #                 break  # stop at the first non-zero (different) value
+        #     return result
 
-        # src_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors + 1)
-        src_neighbor_node_ids = np.concatenate((src_node_ids[:, np.newaxis], src_neighbor_node_ids), axis=1)
-        # src_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors + 1)
-        src_neighbor_edge_ids = np.concatenate((np.zeros((len(src_node_ids), 1)).astype(np.longlong), src_neighbor_edge_ids), axis=1)
-        # src_neighbor_times, ndarray, shape (batch_size, num_neighbors + 1)
-        src_neighbor_times = np.concatenate((node_interact_times[:, np.newaxis], src_neighbor_times), axis=1)
+        # # src_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors + 1)
+        # src_neighbor_node_ids = np.concatenate((src_node_ids[:, np.newaxis], src_neighbor_node_ids), axis=1)
+        # # src_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors + 1)
+        # src_neighbor_edge_ids = np.concatenate((np.zeros((len(src_node_ids), 1)).astype(np.longlong), src_neighbor_edge_ids), axis=1)
+        # # src_neighbor_times, ndarray, shape (batch_size, num_neighbors + 1)
+        # src_neighbor_times = np.concatenate((node_interact_times[:, np.newaxis], src_neighbor_times), axis=1)
+        # # src_neighbor_times = fill_initial_zeros(src_neighbor_times)  # Fill empty values with node_interact_times so that recency will be zero in get_features
 
-        # dst_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors + 1)
-        dst_neighbor_node_ids = np.concatenate((dst_node_ids[:, np.newaxis], dst_neighbor_node_ids), axis=1)
-        # dst_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors + 1)
-        dst_neighbor_edge_ids = np.concatenate((np.zeros((len(dst_node_ids), 1)).astype(np.longlong), dst_neighbor_edge_ids), axis=1)
-        # dst_neighbor_times, ndarray, shape (batch_size, num_neighbors + 1)
-        dst_neighbor_times = np.concatenate((node_interact_times[:, np.newaxis], dst_neighbor_times), axis=1)
+        # # dst_neighbor_node_ids, ndarray, shape (batch_size, num_neighbors + 1)
+        # dst_neighbor_node_ids = np.concatenate((dst_node_ids[:, np.newaxis], dst_neighbor_node_ids), axis=1)
+        # # dst_neighbor_edge_ids, ndarray, shape (batch_size, num_neighbors + 1)
+        # dst_neighbor_edge_ids = np.concatenate((np.zeros((len(dst_node_ids), 1)).astype(np.longlong), dst_neighbor_edge_ids), axis=1)
+        # # dst_neighbor_times, ndarray, shape (batch_size, num_neighbors + 1)
+        # dst_neighbor_times = np.concatenate((node_interact_times[:, np.newaxis], dst_neighbor_times), axis=1)
+        # # dst_neighbor_times = fill_initial_zeros(dst_neighbor_times)  # Fill empty values with node_interact_times so that recency will be zero in get_features
 
-        # pad the features of the sequence of source and destination nodes
-        # src_nodes_neighbor_node_raw_features, Tensor, shape (batch_size, num_neighbors + 1, node_feat_dim)
-        # src_nodes_edge_raw_features, Tensor, shape (batch_size, num_neighbors + 1, edge_feat_dim)
-        # src_nodes_neighbor_time_features, Tensor, shape (batch_size, num_neighbors + 1, time_feat_dim)
-        # src_nodes_neighbor_depth_features, Tensor, shape (num_neighbors + 1, output_dim)
-        src_nodes_neighbor_node_raw_features, src_nodes_edge_raw_features, src_nodes_neighbor_time_features, src_nodes_neighbor_depth_features = \
-            self.get_features(node_interact_times=node_interact_times, nodes_neighbor_ids=src_neighbor_node_ids,
-                              nodes_edge_ids=src_neighbor_edge_ids, nodes_neighbor_times=src_neighbor_times, time_encoder=self.time_encoder)
+        # # pad the features of the sequence of source and destination nodes
+        # # src_nodes_neighbor_node_raw_features, Tensor, shape (batch_size, num_neighbors + 1, node_feat_dim)
+        # # src_nodes_edge_raw_features, Tensor, shape (batch_size, num_neighbors + 1, edge_feat_dim)
+        # # src_nodes_neighbor_time_features, Tensor, shape (batch_size, num_neighbors + 1, time_feat_dim)
+        # # src_nodes_neighbor_depth_features, Tensor, shape (num_neighbors + 1, output_dim)
+        # src_nodes_neighbor_node_raw_features, src_nodes_edge_raw_features, src_nodes_neighbor_time_features, src_nodes_neighbor_depth_features = \
+        #     self.get_features(node_interact_times=node_interact_times, nodes_neighbor_ids=src_neighbor_node_ids,
+        #                       nodes_edge_ids=src_neighbor_edge_ids, nodes_neighbor_times=src_neighbor_times, time_encoder=self.time_encoder)
 
-        # dst_nodes_neighbor_node_raw_features, Tensor, shape (batch_size, num_neighbors + 1, node_feat_dim)
-        # dst_nodes_edge_raw_features, Tensor, shape (batch_size, num_neighbors + 1, edge_feat_dim)
-        # dst_nodes_neighbor_time_features, Tensor, shape (batch_size, num_neighbors + 1, time_feat_dim)
-        # dst_nodes_neighbor_depth_features, Tensor, shape (num_neighbors + 1, output_dim)
-        dst_nodes_neighbor_node_raw_features, dst_nodes_edge_raw_features, dst_nodes_neighbor_time_features, dst_nodes_neighbor_depth_features = \
-            self.get_features(node_interact_times=node_interact_times, nodes_neighbor_ids=dst_neighbor_node_ids,
-                              nodes_edge_ids=dst_neighbor_edge_ids, nodes_neighbor_times=dst_neighbor_times, time_encoder=self.time_encoder)
+        # # dst_nodes_neighbor_node_raw_features, Tensor, shape (batch_size, num_neighbors + 1, node_feat_dim)
+        # # dst_nodes_edge_raw_features, Tensor, shape (batch_size, num_neighbors + 1, edge_feat_dim)
+        # # dst_nodes_neighbor_time_features, Tensor, shape (batch_size, num_neighbors + 1, time_feat_dim)
+        # # dst_nodes_neighbor_depth_features, Tensor, shape (num_neighbors + 1, output_dim)
+        # dst_nodes_neighbor_node_raw_features, dst_nodes_edge_raw_features, dst_nodes_neighbor_time_features, dst_nodes_neighbor_depth_features = \
+        #     self.get_features(node_interact_times=node_interact_times, nodes_neighbor_ids=dst_neighbor_node_ids,
+        #                       nodes_edge_ids=dst_neighbor_edge_ids, nodes_neighbor_times=dst_neighbor_times, time_encoder=self.time_encoder)
+        
+        # # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
+        # src_nodes_neighbor_node_raw_features = self.projection_layer['node'](src_nodes_neighbor_node_raw_features)
+        # src_nodes_edge_raw_features = self.projection_layer['edge'](src_nodes_edge_raw_features)
+        # src_nodes_neighbor_time_features = self.projection_layer['time'](src_nodes_neighbor_time_features)
 
-        # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
-        src_nodes_neighbor_node_raw_features = self.projection_layer['node'](src_nodes_neighbor_node_raw_features)
-        src_nodes_edge_raw_features = self.projection_layer['edge'](src_nodes_edge_raw_features)
-        src_nodes_neighbor_time_features = self.projection_layer['time'](src_nodes_neighbor_time_features)
+        # # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
+        # dst_nodes_neighbor_node_raw_features = self.projection_layer['node'](dst_nodes_neighbor_node_raw_features)
+        # dst_nodes_edge_raw_features = self.projection_layer['edge'](dst_nodes_edge_raw_features)
+        # dst_nodes_neighbor_time_features = self.projection_layer['time'](dst_nodes_neighbor_time_features)
+        
+        
+        
+        # GET FEATURES: ALL NEIGHBORS WITHIN THE BATCH
+        # def find_common_edges(nodes, src_node_ids, dst_node_ids, num_neighbors):
+        #     neighbors = np.empty((len(nodes), num_neighbors+1), dtype=object)
+        #     for idx, node in enumerate(nodes):
+        #         # Get indices where node appears in either src or dst node IDs
+        #         indices = np.where((src_node_ids == node) | (dst_node_ids == node))[0]
+        #         # Get the src & dst tuple for those indices 
+        #         pairs = [(src_node_ids[i], dst_node_ids[i]) for i in indices]
+        #         # Use only the first num_neighbors-th 
+        #         if len(pairs) > num_neighbors:
+        #             pairs = pairs[:num_neighbors] 
+        #         padding = [(0, 0)] * (num_neighbors+1 - len(pairs))
+        #         pairs = padding + pairs
+        #         neighbors[idx,] = pairs
+        #     return neighbors
+        # # get all neighbors within the batch for source nodes
+        # src_neighbor_node_pairs = find_common_edges(src_node_ids, src_node_ids, dst_node_ids, num_neighbors)
+        # # get all neighbors within the batch for source nodes
+        # dst_neighbor_node_pairs = find_common_edges(dst_node_ids, src_node_ids, dst_node_ids, num_neighbors)
+        
+        # # get edge, time and depth features
+        # src_nodes_edge_raw_features, src_nodes_neighbor_time_features, src_nodes_neighbor_depth_features = \
+        #     self.get_features_all(nodes_neighbor_ids=src_neighbor_node_pairs, time_encoder=self.time_encoder)
+        # dst_nodes_edge_raw_features, dst_nodes_neighbor_time_features, dst_nodes_neighbor_depth_features = \
+        #     self.get_features_all(nodes_neighbor_ids=dst_neighbor_node_pairs, time_encoder=self.time_encoder)
+        
+        # # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
+        # src_nodes_edge_raw_features = self.projection_layer['edge'](src_nodes_edge_raw_features)
+        # src_nodes_neighbor_time_features = self.projection_layer['time'](src_nodes_neighbor_time_features)
+        
+        # # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
+        # dst_nodes_edge_raw_features = self.projection_layer['edge'](dst_nodes_edge_raw_features)
+        # dst_nodes_neighbor_time_features = self.projection_layer['time'](dst_nodes_neighbor_time_features)
+        
+        
+        # GET FEATURES: NO NEIGHBORS APPROACH
+        src_nodes_raw_features, src_nodes_time_features = self.get_features_no_neighbors(node_ids=src_node_ids, time_encoder=self.time_encoder)
+        dst_nodes_raw_features, dst_nodes_time_features = self.get_features_no_neighbors(node_ids=dst_node_ids, time_encoder=self.time_encoder)
+        
+        # Tensor, shape (batch_size, output_dim)
+        src_nodes_raw_features = self.projection_layer['node'](src_nodes_raw_features)
+        src_nodes_time_features = self.projection_layer['time'](src_nodes_time_features)
+        
+        # Tensor, shape (batch_size, output_dim)
+        dst_nodes_raw_features = self.projection_layer['node'](dst_nodes_raw_features)
+        dst_nodes_time_features = self.projection_layer['time'](dst_nodes_time_features)
 
-        # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
-        dst_nodes_neighbor_node_raw_features = self.projection_layer['node'](dst_nodes_neighbor_node_raw_features)
-        dst_nodes_edge_raw_features = self.projection_layer['edge'](dst_nodes_edge_raw_features)
-        dst_nodes_neighbor_time_features = self.projection_layer['time'](dst_nodes_neighbor_time_features)
 
         # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
         # src_node_features = src_nodes_neighbor_node_raw_features + src_nodes_edge_raw_features + src_nodes_neighbor_time_features + src_nodes_neighbor_depth_features
-        src_node_features = src_nodes_edge_raw_features + src_nodes_neighbor_time_features + src_nodes_neighbor_depth_features
         # Tensor, shape (batch_size, num_neighbors + 1, output_dim)
         # dst_node_features = dst_nodes_neighbor_node_raw_features + dst_nodes_edge_raw_features + dst_nodes_neighbor_time_features + dst_nodes_neighbor_depth_features
-        dst_node_features = dst_nodes_edge_raw_features + dst_nodes_neighbor_time_features + dst_nodes_neighbor_depth_features
+        # # Tensor, shape (batch_size, 1, output_dim)
+        src_node_features = src_nodes_time_features
+        src_neighbor_node_ids = np.expand_dims(src_node_ids, axis=1)
+        # # Tensor, shape (batch_size, 1, output_dim)
+        dst_node_features = dst_nodes_time_features
+        dst_neighbor_node_ids = np.expand_dims(dst_node_ids, axis=1)
 
         for transformer in self.transformers:
             # self-attention block
@@ -152,13 +221,39 @@ class TCL(nn.Module):
         # retrieve the embedding of the corresponding target node, which is at the first position of the sequence
         # Tensor, shape (batch_size, output_dim)
         src_node_embeddings = self.output_layer(src_node_embeddings[:, 0, :])
+        # src_node_embeddings = self.output_layer(src_node_embeddings[:, 0, :]) + src_node_features # (optional: add the input to output to counter degradation problem)
         # Tensor, shape (batch_size, output_dim)
         dst_node_embeddings = self.output_layer(dst_node_embeddings[:, 0, :])
+        # dst_node_embeddings = self.output_layer(dst_node_embeddings[:, 0, :]) + dst_node_features # (optional: add the input to output to counter degradation problem)
 
         return src_node_embeddings, dst_node_embeddings
 
+    def get_features_no_neighbors(self, node_ids: np.ndarray, time_encoder: TimeEncoder):
+        """
+        get node (either src or dst) and time features
+        :param node_ids: ndarray, shape (batch_size, 1)
+        :param time_encoder: TimeEncoder, time encoder
+        :return:
+        """
+        # Load mappings for edge-node pairs and id-date information
+        edge_node_pairs = np.loadtxt("image_data/edge_node_pairs.txt", delimiter="\t", dtype=np.int64)
+        node_mapping = np.loadtxt("image_data/node_mapping.txt", dtype={'names': ('nodeID', 'date', 'doy'), 'formats': ('i8', 'U10', 'i8')})
+        id_to_timestamp = {row['nodeID']: row['date'] for row in node_mapping}
+        id_to_doy = {row['nodeID']: row['doy'] for row in node_mapping}
+        
+        # Tensor, shape (batch_size, 1, node_feat_dim)
+        nodes_raw_features = self.node_raw_features[torch.from_numpy(node_ids[:, np.newaxis])]
+        
+        # Tensor, shape (batch_size, 1, time_feat_dim)
+        doys = np.zeros_like(node_ids, dtype=np.int64)
+        for i in range(node_ids.shape[0]):
+            doys[i] = id_to_doy.get(node_ids[i], 0)
+        nodes_time_features = time_encoder(timestamps=torch.from_numpy(doys[:, np.newaxis]).float().to(self.device))
+        
+        return nodes_raw_features, nodes_time_features
+    
     def get_features(self, node_interact_times: np.ndarray, nodes_neighbor_ids: np.ndarray, nodes_edge_ids: np.ndarray,
-                     nodes_neighbor_times: np.ndarray, time_encoder: TimeEncoder):
+                        nodes_neighbor_times: np.ndarray, time_encoder: TimeEncoder):
         """
         get node, edge, time and depth features
         :param node_interact_times: ndarray, shape (batch_size, )
@@ -168,17 +263,125 @@ class TCL(nn.Module):
         :param time_encoder: TimeEncoder, time encoder
         :return:
         """
+        # Load mappings for edge-node pairs and id-date information
+        edge_node_pairs = np.loadtxt("image_data/edge_node_pairs.txt", delimiter="\t", dtype=np.int64)
+        node_mapping = np.loadtxt("image_data/node_mapping.txt", dtype={'names': ('nodeID', 'date', 'doy'), 'formats': ('i8', 'U10', 'i8')})
+        id_to_timestamp = {row['nodeID']: row['date'] for row in node_mapping}
+        id_to_doy = {row['nodeID']: row['doy'] for row in node_mapping}
+        
         # Tensor, shape (batch_size, num_neighbors + 1, node_feat_dim)
         nodes_neighbor_node_raw_features = self.node_raw_features[torch.from_numpy(nodes_neighbor_ids)]
+        
         # Tensor, shape (batch_size, num_neighbors + 1, edge_feat_dim)
         nodes_edge_raw_features = self.edge_raw_features[torch.from_numpy(nodes_edge_ids)]
+        
         # Tensor, shape (batch_size, num_neighbors + 1, time_feat_dim)
-        nodes_neighbor_time_features = time_encoder(timestamps=torch.from_numpy(node_interact_times[:, np.newaxis] - nodes_neighbor_times).float().to(self.device))
+        # Original: time feature is recency i.e. the time difference between current interaction and neighbor interactions "how long ago did this node interact with its neighbors relative to now?"
+        # CT: Not sure if this logic makes sense for coherences? e.g. for coherence 6-10, current time=10 because 6-10 only occurs at time=10, which makes time difference relative to now=0,
+        # but isn't what's more important is the time difference between 6 and 10 themselves which is 4? It doesn't matter what time 6-10 occurred?
+        # nodes_neighbor_time_features = time_encoder(timestamps=torch.from_numpy(node_interact_times[:, np.newaxis] - nodes_neighbor_times).float().to(self.device))
+        
+        # Alternative: time feature is recency, but using time difference in no. of days instead of no. of IDs
+        from datetime import datetime
+        recency_time_diffs = np.zeros_like(nodes_edge_ids, dtype=np.int64)
+        recency = node_interact_times[:, np.newaxis] - nodes_neighbor_times
+        for i in range(recency.shape[0]):
+            current_time = node_interact_times[i]
+            current_time_date = datetime.strptime(node_mapping[node_mapping['nodeID']==current_time]['date'][0], "%Y%m%d")
+            for j in range(recency.shape[1]):
+                if recency[i, j] == 0:
+                    recency_time_diffs[i, j] = 0
+                    continue
+                if recency[i, j] == current_time:
+                    recency_time_diffs[i, j] = 9999 # Set to a large value if the recency is equal to the current time
+                    continue
+                past_time = current_time - recency[i, j]
+                past_time_date = datetime.strptime(node_mapping[node_mapping['nodeID']==past_time]['date'][0], "%Y%m%d")
+                recency_time_diffs[i, j] = abs((current_time_date - past_time_date).days)
+        nodes_neighbor_time_features = time_encoder(timestamps=torch.from_numpy(recency_time_diffs).float().to(self.device))
+
+        # Alternative: time feature is the time difference between the src and dst nodes which form the edge
+        # from datetime import datetime
+        # edge_time_diffs = np.zeros_like(nodes_edge_ids, dtype=np.int64)
+        # for i in range(nodes_edge_ids.shape[0]):
+        #     for j in range(nodes_edge_ids.shape[1]):
+        #         edge_id = nodes_edge_ids[i, j]
+        #         if edge_id == 0: # Skip or set to 0 if there is no edge
+        #             edge_time_diffs[i, j] = 0
+        #             continue
+        #         src_id, dst_id = edge_node_pairs[edge_id-1]
+        #         src_id_date = datetime.strptime(node_mapping[node_mapping['nodeID']==src_id]['date'][0], "%Y%m%d")
+        #         dst_id_date = datetime.strptime(node_mapping[node_mapping['nodeID']==dst_id]['date'][0], "%Y%m%d")
+        #         edge_time_diffs[i, j] = abs((src_id_date - dst_id_date).days)
+        # nodes_neighbor_time_features = time_encoder(timestamps=torch.from_numpy(edge_time_diffs).float().to(self.device))
+        
+        # Alternative: time feature is simply the time of the node neighbour
+        # doys = np.zeros_like(nodes_neighbor_ids, dtype=np.int64)
+        # for i in range(nodes_neighbor_ids.shape[0]):
+        #     current_time = node_interact_times[i]
+        #     for j in range(nodes_neighbor_ids.shape[1]):
+        #         node_id = nodes_neighbor_ids[i, j]
+        #         if node_id == 0: # Skip or set to 0 if there is no node
+        #             doys[i, j] = 0
+        #             continue
+        #         if node_id == current_time:
+        #             doys[i, j] = 9999 # Set to a large value if the node ID is equal to the current time
+        #             continue
+        #         doys[i, j] = id_to_doy.get(node_id, 0)
+        # nodes_neighbor_time_features = time_encoder(timestamps=torch.from_numpy(doys).float().to(self.device))
+        
+        # Ensure the number of neighbors assigned per node matches the number of depth embeddings available
         assert nodes_neighbor_ids.shape[1] == self.depth_embedding.weight.shape[0]
+        
         # Tensor, shape (num_neighbors + 1, output_dim)
         nodes_neighbor_depth_features = self.depth_embedding(torch.tensor(range(nodes_neighbor_ids.shape[1])).to(self.device))
 
         return nodes_neighbor_node_raw_features, nodes_edge_raw_features, nodes_neighbor_time_features, nodes_neighbor_depth_features
+    
+    def get_features_all(self, nodes_neighbor_ids: np.ndarray, time_encoder: TimeEncoder):
+        """
+        get edge, time and depth features
+        :param nodes_neighbor_ids: ndarray, shape (batch_size, num_neighbors + 1) 
+        :param time_encoder: TimeEncoder, time encoder
+        :return:
+        """
+        # Load mappings for edge-node pairs and id-date information
+        edge_node_pairs = np.loadtxt("image_data/edge_node_pairs.txt", delimiter="\t", dtype=np.int64)
+        node_mapping = np.loadtxt("image_data/node_mapping.txt", dtype={'names': ('nodeID', 'date', 'doy'), 'formats': ('i8', 'U10', 'i8')})
+        id_to_timestamp = {row['nodeID']: row['date'] for row in node_mapping}
+        id_to_doy = {row['nodeID']: row['doy'] for row in node_mapping}
+        
+        # Get corresponding edge IDs for nodes_neighbor_ids
+        from datetime import datetime
+        edges_neighbor_ids = np.zeros_like(nodes_neighbor_ids, dtype=np.int64)
+        edge_time_diffs = np.zeros_like(nodes_neighbor_ids, dtype=np.int64)
+        for i in range(edges_neighbor_ids.shape[0]):
+            for j in range(edges_neighbor_ids.shape[1]):
+                pair = np.array(nodes_neighbor_ids[i, j])
+                if np.array_equal(pair,[0,0]):  
+                    edges_neighbor_ids[i, j] = 0  # Skip or set to 0 if there is no node
+                    edge_time_diffs[i, j] = 0
+                else:
+                    matches = np.all(edge_node_pairs == pair, axis=1)
+                    edges_neighbor_ids[i, j] = np.where(matches)[0] + 1
+                    src_id_date = datetime.strptime(node_mapping[node_mapping['nodeID']==pair[0]]['date'][0], "%Y%m%d")
+                    dst_id_date = datetime.strptime(node_mapping[node_mapping['nodeID']==pair[1]]['date'][0], "%Y%m%d")
+                    edge_time_diffs[i, j] = abs((src_id_date - dst_id_date).days)
+        
+        # Tensor, shape (batch_size, num_neighbors + 1, edge_feat_dim)
+        nodes_edge_raw_features = self.edge_raw_features[torch.from_numpy(edges_neighbor_ids)]
+        
+        # Tensor, shape (batch_size, num_neighbors + 1, time_feat_dim)
+        # Time feature is the time difference between the src and dst nodes which form the edge
+        nodes_neighbor_time_features = time_encoder(timestamps=torch.from_numpy(edge_time_diffs).float().to(self.device))
+        
+        # Ensure the number of neighbors assigned per node matches the number of depth embeddings available
+        assert nodes_neighbor_ids.shape[1] == self.depth_embedding.weight.shape[0]
+        
+        # Tensor, shape (num_neighbors + 1, output_dim)
+        nodes_neighbor_depth_features = self.depth_embedding(torch.tensor(range(nodes_neighbor_ids.shape[1])).to(self.device))
+
+        return nodes_edge_raw_features, nodes_neighbor_time_features, nodes_neighbor_depth_features
 
     def set_neighbor_sampler(self, neighbor_sampler: NeighborSampler):
         """

--- a/models/modules.py
+++ b/models/modules.py
@@ -56,10 +56,10 @@ class MergeLayer(nn.Module):
 
         # Sigmoid activation function with temperature scaling (y = 1 / (1 + e^(-x/temperature)))
         # Default sigmoid temperature is set to 1
-        # If temperature is set to < 1, it will make the sigmoid function sharper
-        # If temperature is set to > 1, it will make the sigmoid function smoother
-        temperature = 1
-        self.final_act = lambda x: torch.sigmoid(x / temperature)
+        # If sigmoid temperature is set to < 1, it will make the sigmoid function steeper
+        # If sigmoid temperature is set to > 1, it will make the sigmoid function gentler
+        sigmoid_temperature = 1
+        self.final_act = lambda x: torch.sigmoid(x / sigmoid_temperature)
 
         # self.final_act = nn.Sigmoid()   
         # self.final_act = lambda x: torch.clamp(x, min=0.0, max=1.0)

--- a/utils/DataLoader.py
+++ b/utils/DataLoader.py
@@ -293,9 +293,8 @@ def get_link_prediction_image_data_split_by_nodes(logger, dataset_name: str):
     save_dir = os.path.join(os.getcwd(), "image_data")
     node_raw_features = np.load(os.path.join(save_dir, "node_features.npy"))  # shape: (num_nodes, feat_dim)
     edge_raw_features = np.load(os.path.join(save_dir, "edge_features.npy"))  # shape: (num_edges, feat_dim)
-    # Load edge-node pairs; each line has "source<TAB>target"
-    edge_node_pairs = np.loadtxt(os.path.join(save_dir, "edge_node_pairs.txt"), delimiter="\t", dtype=np.int64)
-
+    edge_node_pairs = np.loadtxt(os.path.join(save_dir, "edge_node_pairs.txt"), delimiter="\t", dtype=np.int64)  # Load edge-node pairs; each line has "source<TAB>target"
+    
     # In our pre-generated data, we assume:
     #   - node IDs in edge_node_pairs are 0-indexed.
     #   - node_raw_features has shape (num_nodes, feat_dim) and edge_raw_features (num_edges, feat_dim)

--- a/utils/isce_tools.py
+++ b/utils/isce_tools.py
@@ -117,7 +117,6 @@ def computePatches(image_file, image_x, image_y, patch_length, patch_overlap):
     return patchList
 
 
-# def prepareData(logger, data_in_dir, data_out_dir, bbox, base_filename='b01_16r4alks', **kwargs):
 def prepareData(logger, data_in_dir, data_out_dir, bbox, **kwargs):
 
     # Create a directory "image_data" in the current folder to store outputs

--- a/utils/isce_tools.py
+++ b/utils/isce_tools.py
@@ -105,7 +105,8 @@ def computePatches(image_x, image_y, patch_length, patch_overlap):
     return patchList
 
 
-def prepareData(logger, data_in_dir, data_out_dir, bbox, base_filename='b01_16r4alks'):
+# def prepareData(logger, data_in_dir, data_out_dir, bbox, base_filename='b01_16r4alks', **kwargs):
+def prepareData(logger, data_in_dir, data_out_dir, bbox, **kwargs):
 
     # Create a directory "image_data" in the current folder to store outputs
     logger.info(f"\n\n\nPreparing data in {data_out_dir}...\n\n")
@@ -129,8 +130,24 @@ def prepareData(logger, data_in_dir, data_out_dir, bbox, base_filename='b01_16r4
             continue
         date1, date2 = parts[1], parts[2]
         folder_path = os.path.join(data_in_dir, folder)
-        amp_file = os.path.join(folder_path, base_filename + "_norm.amp")
-        cor_file = os.path.join(folder_path, base_filename + ".cor")
+
+        # Extract base_filename from files in the folder based on common name parts
+        base_filename = os.path.commonprefix([os.path.splitext(f)[0] for f in os.listdir(folder_path) if not f.startswith('.')])
+
+        # Read in the relevant amplitude files depending on whether normalisation is applied
+        amp_norm = kwargs.get("amp_norm", None)
+        if amp_norm == True:
+            amp_file = os.path.join(folder_path, base_filename + "_norm.amp")
+        else:
+            amp_file = os.path.join(folder_path, base_filename + ".amp")
+
+        # Read in the relevant coherence files depending on whether logit space is applied
+        cor_logit = kwargs.get("cor_logit", None)
+        if cor_logit == True:
+            cor_file = os.path.join(folder_path, base_filename + "_logit.cor")
+        else:
+            cor_file = os.path.join(folder_path, base_filename + ".cor")
+
         logger.info(f"\n"
                     f"Reading folder {folder} with dates {date1} and {date2}\n"
                     f"{amp_file}\n"

--- a/utils/load_configs.py
+++ b/utils/load_configs.py
@@ -17,9 +17,11 @@ def get_link_prediction_args(is_evaluation: bool = False):
     parser.add_argument('--cor_logit', type=bool, default=False, help='Boolean flag to determine if coherences should be converted to logit space')
     parser.add_argument('--patch_length', type=int, default=224, help='patch length')
     parser.add_argument('--patch_overlap', type=int, default=204, help='patch overlap')
+    parser.add_argument('--batch_size', type=int, default=55, help='batch size')
     parser.add_argument('--temporal_window_width', type=int, default=120, help='temporal window width in number of days')
     parser.add_argument('--temporal_window_stride', type=int, default=1, help='temporal window stride')
-    parser.add_argument('--batch_size', type=int, default=55, help='batch size')
+    parser.add_argument('--min_num_total_edges_valid_training_window', type=int, default=40, help='number of edges in total required for each temporal sliding window for it to undergo training. If not met, skip training for the window.')
+    parser.add_argument('--min_num_new_edges_valid_training_window', type=int, default=5, help='number of new edges required for each temporal sliding window for it to undergo training. If not met, skip training for the window.')
     parser.add_argument('--model_name', type=str, default='DyGFormer', help='name of the model, note that EdgeBank is only applicable for evaluation',
                         choices=['JODIE', 'DyRep', 'TGAT', 'TGN', 'CAWN', 'EdgeBank', 'TCL', 'GraphMixer', 'DyGFormer'])
     parser.add_argument('--gpu', type=int, default=0, help='number of gpu to use')
@@ -57,8 +59,6 @@ def get_link_prediction_args(is_evaluation: bool = False):
     parser.add_argument('--load_best_configs', action='store_true', default=False, help='whether to load the best configurations')
     parser.add_argument('--stitch_method', type=str, default='median', choices=['mean', 'median'], help='method to handle overlap areas when stitching patches')
     parser.add_argument('--stitch_chunk_size', type=int, default=500, help='chunk size used for median stitching')
-    parser.add_argument('--min_num_total_edges_valid_training_window', type=int, default=40, help='number of edges in total required for each temporal sliding window for it to undergo training. If not met, skip training for the window.')
-    parser.add_argument('--min_num_new_edges_valid_training_window', type=int, default=5, help='number of new edges required for each temporal sliding window for it to undergo training. If not met, skip training for the window.')
 
     try:
         args = parser.parse_args()

--- a/utils/load_configs.py
+++ b/utils/load_configs.py
@@ -13,6 +13,8 @@ def get_link_prediction_args(is_evaluation: bool = False):
     parser = argparse.ArgumentParser('Interface for the link prediction task')
     parser.add_argument('--dataset_name', type=str, help='dataset to be used', default='tgbl-wiki',
                         choices=["tgbl-wiki", "tgbl-review", "tgbl-coin", "tgbl-comment", "tgbl-flight"])
+    parser.add_argument('--amp_norm', type=bool, default=True, help='Boolean flag to determine if raw amplitudes or normalised amplitudes should be used')
+    parser.add_argument('--cor_logit', type=bool, default=False, help='Boolean flag to determine if coherences should be converted to logit space')
     parser.add_argument('--patch_length', type=int, default=224, help='patch length')
     parser.add_argument('--patch_overlap', type=int, default=204, help='patch overlap')
     parser.add_argument('--temporal_window_width', type=int, default=120, help='temporal window width in number of days')
@@ -49,7 +51,7 @@ def get_link_prediction_args(is_evaluation: bool = False):
     parser.add_argument('--l1_regularisation_lambda', type=float, default=0.0, help='L1 regularisation (Lasso) lambda hyperparameter')
     parser.add_argument('--l2_regularisation_lambda', type=float, default=0.0, help='L2 regularisation (Ridge) lambda hyperparameter')
     parser.add_argument('--patience', type=int, default=10, help='patience for early stopping in terms of no. of epochs')
-    parser.add_argument('--patience_threshold', type=int, default=0.005, help='patience for early stopping in terms of loss threshold, stop early if loss does not improve significantly enough e.g. by 0.005')
+    parser.add_argument('--patience_threshold', type=float, default=0.005, help='patience for early stopping in terms of loss threshold, stop early if loss does not improve significantly enough e.g. by 0.005')
     parser.add_argument('--num_runs', type=int, default=5, help='number of runs')
     parser.add_argument('--test_interval_epochs', type=int, default=10, help='how many epochs to perform testing once')
     parser.add_argument('--load_best_configs', action='store_true', default=False, help='whether to load the best configurations')

--- a/utils/plot_loss.py
+++ b/utils/plot_loss.py
@@ -1,0 +1,48 @@
+import re
+import matplotlib.pyplot as plt
+
+# Path to your log file
+log_file = "/Users/cheryltay/Documents/project_dpm5/NoNeighbor_NodeFeatOnly/patch_0004/logs/logger_20250709_214125.log"
+
+# Lists to hold the extracted losses
+train_losses = []
+val_losses = []
+test_loss = None  # Initialize test_loss
+
+# Regex patterns
+train_pattern = re.compile(r"train mean Training MAE loss, ([0-9.]+)")
+val_pattern = re.compile(r"validate mean val MAE loss, ([0-9.]+)")
+test_pattern = re.compile(r"test test_end MAE loss, ([0-9.]+)")
+
+# Read and extract losses
+with open(log_file, 'r') as file:
+    for line in file:
+        train_match = train_pattern.search(line)
+        val_match = val_pattern.search(line)
+        test_match = test_pattern.search(line)
+
+        if train_match:
+            train_losses.append(float(train_match.group(1)))
+        if val_match:
+            val_losses.append(float(val_match.group(1)))
+        if test_match and test_loss is None:  # Capture only the first test loss
+            test_loss = float(test_match.group(1))
+
+# Plotting
+plt.figure(figsize=(8, 6))
+plt.plot(train_losses, label='Training MAE Loss', marker='o')
+plt.plot(val_losses, label='Validation MAE Loss', marker='x')
+
+# Add test loss as a horizontal line if found
+if test_loss is not None:
+    plt.axhline(y=test_loss, color='red', linestyle='--', label=f'Test MAE Loss = {test_loss:.4f}')
+
+plt.ylim(0, 0.45)
+plt.xlabel("Epoch", fontsize=20)
+plt.ylabel("MAE Loss", fontsize=20)
+plt.legend(fontsize=18)
+plt.grid(True)
+plt.xticks(fontsize=18)
+plt.yticks(fontsize=18)
+plt.tight_layout()
+plt.savefig(log_file.replace('.log', '_loss_plot.png'))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -98,9 +98,9 @@ class NeighborSampler:
             # sort the list based on timestamps, sorted() function is stable
             # Note that sort the list based on edge id is also correct, as the original data file ensures the interactions are chronological
             sorted_per_node_neighbors = sorted(per_node_neighbors, key=lambda x: x[2])
-            self.nodes_neighbor_ids.append(np.array([x[0] for x in sorted_per_node_neighbors]))
-            self.nodes_edge_ids.append(np.array([x[1] for x in sorted_per_node_neighbors]))
-            self.nodes_neighbor_times.append(np.array([x[2] for x in sorted_per_node_neighbors]))
+            self.nodes_neighbor_ids.append(np.array([x[0] for x in sorted_per_node_neighbors]))  # Contains IDs of all nodes which this node has interacted with, regardless of backward or forward direction
+            self.nodes_edge_ids.append(np.array([x[1] for x in sorted_per_node_neighbors]))  # Contains IDs of all edges which this node is involved in, regardless of backward or forward direction
+            self.nodes_neighbor_times.append(np.array([x[2] for x in sorted_per_node_neighbors]))  # Contains all timestamps at which this node interacted with other nodes, regardless of backward or forward direction
 
             # additional for time interval aware sampling strategy (proposed in CAWN paper)
             if self.sample_neighbor_strategy == 'time_interval_aware':


### PR DESCRIPTION
1. Time features 
- Use fixed time features, made them untrainable
- Added day of year to node_mapping.txt
- Use actual time information (e.g. yyyymmdd timestamp / day of year / time difference) instead of arbitrary ID (e.g. 1,2,3,4,...)
- Replaced original simple encoding with sine-cosine encoding

2. Different constructions of node, edge, time, depth features (lots of commented code in TCL.py used for different constructions listed below)
- [Original] Neighbour approach, time feature is the recency, referring to the time difference between the "current interaction time" and the "past neighbour interaction time", meaning "how long ago did this node interact with its neighbours relative to now?"
- Neighbour approach, time feature is the recency as above, but using time difference in terms of no. of days instead of time difference in terms of arbitrary ID difference
- Neighbour approach, time feature is the time difference between the source and destination nodes forming the edge
- Neighbour approach, time feature is the time of the node neighbour 
- Neighbour approach, expanded to forward and backward neighbours (instead of using only historical neighbours), time feature is the time difference between the source and destination nodes forming the edge
- [Current implementation] No-neighbour approach, ignore neighbours, simply use the node itself (either time only, amp only, or both, recommended to use time only based on current testing), time feature is defined as day of year of the node 

3. Removed edge features (coherences) from TCL model because
- Coherences are the labels, the label is the target output and not the input feature, it is the thing the model is supposed to learn or predict
- It is not scientific to use the labels during the training as this would result in data leakage

4. Added plot to visualise patch splitting for easy reference of where each patch is within the image

5. Streamlined visualisation and distribution plots for training, validation, testing 

6. Added flexibility for patch stitching
- Whatever patch and whatever edge available will be stitched through "median" method
- Train and validate stages can also be stitched, useful for debugging
- "Mean" method has not been updated and should be deprecated, mean does not give good results compared to median as it is affected by outliers more strongly

7. Added installation notes in README
